### PR TITLE
Parameterized watchlist loop interval rather than hardcoded 30 minutes

### DIFF
--- a/content/classes.py
+++ b/content/classes.py
@@ -926,17 +926,19 @@ class media:
                         retries = int(float(trigger[2]))
         if retries == 0:
             return
+
+        message = 'retrying download in ' + str(
+            round(int(ui_settings.loop_interval_seconds) / 60)) + 'min for item: ' + self.query() + ' - version/s [' + '],['.join(
+            names) + ']'
         if not self in media.ignore_queue:
             self.ignored_count = 1
             media.ignore_queue += [self]
-            ui_print('retrying download in 30min for item: ' + self.query() + ' - version/s [' + '],['.join(
-                names) + '] - attempt ' + str(self.ignored_count) + '/' + str(retries))
+            ui_print(message + ' - attempt ' + str(self.ignored_count) + '/' + str(retries))
         else:
             match = next((x for x in media.ignore_queue if self == x), None)
             if match.ignored_count < retries:
                 match.ignored_count += 1
-                ui_print('retrying download in 30min for item: ' + self.query() + ' - version/s [' + '],['.join(
-                    names) + '] - attempt ' + str(match.ignored_count) + '/' + str(retries))
+                ui_print(message + ' - attempt ' + str(match.ignored_count) + '/' + str(retries))
             else:
                 media.ignore_queue.remove(match)
                 ignore.add(self)

--- a/settings/__init__.py
+++ b/settings/__init__.py
@@ -412,6 +412,7 @@ settings_list = [
         setting('Show Menu on Startup', 'Please enter "true" or "false": ', ui_settings, 'run_directly'),
         setting('Debug printing', 'Please enter "true" or "false": ', ui_settings, 'debug'),
         setting('Log to file', 'Please enter "true" or "false": ', ui_settings, 'log'),
+        setting('Watchlist loop interval (sec)', 'Please enter an integer value in seconds: ', ui_settings, 'loop_interval_seconds'),
         setting('version', 'No snooping around! :D This is for compatability reasons.', ui_settings, 'version',
                 hidden=True),
     ]

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -403,7 +403,7 @@ def threaded(stop):
     else:
         print("Type 'exit' to return to the main menu.")
     timeout = 5
-    regular_check = 1800
+    regular_check = int(ui_settings.loop_interval_seconds)
     timeout_counter = 0
     library = content.classes.library()[0]()
     # get entire plex_watchlist

--- a/ui/ui_settings.py
+++ b/ui/ui_settings.py
@@ -2,3 +2,4 @@ version = ['2.95', "Settings compatible update", []]
 run_directly = "true"
 debug = "false"
 log = "false"
+loop_interval_seconds = 1800


### PR DESCRIPTION
Allows the watchlist download interval to be configured in the settings.json. Default value is 30 minutes (1800 seconds).

This is the interval in which an attempt is made to find anything that is in the watchlist but not yet in the library, not to be confused with the interval in which the watchlist is checked for new items.