### PR TITLE
Fix retries trigger with operation ==

### DIFF
--- a/releases/__init__.py
+++ b/releases/__init__.py
@@ -1054,8 +1054,8 @@ class sort:
                             return True
                         return False
                 else:
-                    if self.operator == "==" and float(self.value) == 0:
-                        return True
+                    if self.operator == "==":
+                        return float(self.value) == 0
                     if self.operator == ">=":
                         return False
                     if self.operator == "<=":


### PR DESCRIPTION
There fixes a problem when defining a rule with the retries trigger using the == operator.
For example, if I define a rule where retries == 4, then I would expect the _first time_ this rule fires is during the fourth pass (when the media item is still not in the library). However, a rule with this trigger would always fire on the first pass which would lead to duplicate identical items being added (because multiple rules fired during the first pass).