### PR TITLE
Removes requirement to have at least one item in each Plex library

### DIFF
--- a/content/services/plex.py
+++ b/content/services/plex.py
@@ -801,6 +801,7 @@ class library(classes.library):
             if section == '':
                 continue
             section_response = []
+            section_title = ''
             for type in types:
                 url = library.url + '/library/sections/' + section + '/all?type=' + type + '&X-Plex-Token=' + users[0][1]
                 response = get(url)
@@ -808,14 +809,15 @@ class library(classes.library):
                     if hasattr(response.MediaContainer, 'Metadata'):
                         for element in response.MediaContainer.Metadata:
                             section_response += [classes.media(element)]
+                    if hasattr(response.MediaContainer, 'librarySectionTitle'):
+                        section_title = response.MediaContainer.librarySectionTitle
             if len(section_response) == 0:
-                ui_print("[plex error]: couldnt reach local plex library section '" + section + "' at server address: " + library.url + " - or this library really is empty.")
-                list_ = []
-                break
+                ui_print(f"[plex error]: local plex library section [{section}]: {section_title} at server address: {library.url} is empty!")
+                continue
             else:
                 list_ += section_response
         if len(list_) == 0:
-            ui_print("[plex error]: Your library seems empty. To prevent unwanted behaviour, no further downloads will be started. If your library really is empty, please add at least one media item manually.")
+            ui_print("[plex error]: No library items were found.")
         shows = {}
         seasons = {}
         for item in list_:

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -488,8 +488,6 @@ def threaded(stop):
                 ui_print("couldnt sort monitored media by newest, using default order.", ui_settings.debug)
             library = content.classes.library()[0]()
             timeout_counter = 0
-            if len(library) == 0:
-                continue
             ui_print('checking new content ...')
             t0 = time.time()
             for element in unique(watchlists):


### PR DESCRIPTION
Tested by adding a film/show into an empty library. Didn't seem to break anything...
Also tried changing the plex server URL to a non-resolvable host. Timeout as expected with an error reported to the console.