### PR TITLE
Enable "cached" support for realdebrid version rules

### DIFF
--- a/content/classes.py
+++ b/content/classes.py
@@ -1538,7 +1538,7 @@ class media:
                 ver_dld = False
                 for release in copy.deepcopy(self.Releases):
                     self.Releases = [release,]
-                    if hasattr(release, "cached") and len(release.cached) > 0:
+                    if (hasattr(release, "cached") and len(release.cached) > 0) or (hasattr(release, "maybe_cached") and len(release.maybe_cached) > 0):
                         if debrid.download(self, stream=True, force=force):
                             self.downloaded()
                             downloaded += [True]
@@ -1597,16 +1597,16 @@ class media:
     def season_pack(self, releases):
         season_releases = -1
         episode_releases = [-2] * len(self.Episodes)
-        for release in self.Releases:
-            if len(release.cached) > 0 and int(release.resolution) > season_releases:
+        for release in self.Releases:  # find the highest resolution of all the cached releases
+            if len(release.cached) + len(release.maybe_cached) > 0 and int(release.resolution) > season_releases:
                 season_releases = int(release.resolution)
-        for i, episode in enumerate(self.Episodes):
+        for i, episode in enumerate(self.Episodes):  # find the highest resolution for each episode
             ep_match = regex.compile(episode.deviation(), regex.IGNORECASE)
             for release in releases:
-                if len(release.cached) > 0 and int(release.resolution) >= season_releases and int(release.resolution) > episode_releases[i] and ep_match.match(release.title):
+                if len(release.cached) + len(release.maybe_cached) > 0 and int(release.resolution) >= season_releases and int(release.resolution) > episode_releases[i] and ep_match.match(release.title):
                     episode_releases[i] = int(release.resolution)
         lowest = 2160
-        for quality in episode_releases:
+        for quality in episode_releases:  # find the lowest resolution of all the episodes
             if quality < lowest:
                 lowest = quality
         # If no cached episode release available for all episodes, or the quality is equal or lower to the cached season packs return True

--- a/debrid/__init__.py
+++ b/debrid/__init__.py
@@ -20,7 +20,7 @@ def download(element, stream=True, query='', force=False):
                     if regex.search(t, release.source, regex.I):
                         release.cached = s
             for service in services.get():
-                if service.short in release.cached:
+                if service.short in release.cached + release.maybe_cached:
                     if service.download(element, stream=stream, query=query, force=force):
                         downloaded = True
                         downloaded_files += element.Releases[0].files
@@ -47,7 +47,7 @@ def download(element, stream=True, query='', force=False):
                         release.cached = s
             for service in services.get():
                 if len(release.cached) > 0:
-                    if service.short in release.cached:
+                    if service.short in release.cached + release.maybe_cached:
                         if service.download(element, stream=stream, query=query, force=force):
                             downloaded = True
                             downloaded_files += element.Releases[0].files

--- a/releases/__init__.py
+++ b/releases/__init__.py
@@ -27,6 +27,7 @@ class release:
             if regex.search(r'(?<=btih:).*?(?=&)', str(self.download[0]), regex.I):
                 self.hash = regex.findall(r'(?<=btih:).*?(?=&)', str(self.download[0]), regex.I)[0]
         self.cached = []
+        self.maybe_cached = []  # services where cached state can only be determined at time of download
         self.checked = False
         self.wanted = 0
         self.unwanted = 0

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -171,7 +171,8 @@ def scrape():
                                         "There was an error adding this uncached torrent to your debrid service. Choose another release?")
                     elif choice == '0':
                         back = True
-                except:
+                except Exception as e:
+                    print("error: " + str(e))
                     back = False
         else:
             print("No releases were found!")


### PR DESCRIPTION
This adds a `maybe_cached` attribute to the `Release` object for services such as RD where there is no longer the ability to check what is cached on their service anymore (the "instantAvailability" endpoint has been removed). This is so we can still attempt to download a release within the context of a PD version where `cache status == 'cached'` while also not showing the cache state in the console/log file when displaying the list of search results (since we don't know it).

The previous process was:
1. Search torrent
2. Sort results (based on PD version rules)
3. Check which of the results are cached (call to instantAvailability endpoint)
4. Download (cached/uncached based on PD version rules)

We will tweak this slightly. For `cache status == 'cached'`:
1. Search torrent
2. Sort results (based on PD version rules)
3. Attempt download in order (If download is not cached, delete and try the next one down on the list)
4. Continue until we find a cached download, or we run out of items on the list. 

And where `cache status == 'uncached'`, this is simply:
1. Search torrent
2. Sort results (based on PD version rules)
3. Download first entry on list

If you've previously removed the 'cache status' from any of your version rules (under /Options/Settings/Scraper Settings/Versions), you can add them back in now! 
