### PR TITLE
Empty plex library prevents new watchlisted items from being downloaded

### DIFF
--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -451,8 +451,6 @@ def threaded(stop):
     while not stop():
         if plex_watchlist.update() or overseerr_requests.update() or trakt_watchlist.update():
             library = content.classes.library()[0]()
-            if len(library) == 0:
-                continue
             watchlists = plex_watchlist + trakt_watchlist + overseerr_requests
             try:
                 watchlists.data.sort(key=lambda s: s.watchlistedAt,reverse=True)


### PR DESCRIPTION
Watchlisting a media item with an empty library should work now.
Not sure how I missed from https://github.com/elfhosted/plex_debrid/pull/12
