### PR TITLE
Fixing up Comet exception handling

### DIFF
--- a/scraper/services/comet.py
+++ b/scraper/services/comet.py
@@ -27,7 +27,11 @@ def request(func, *args):
     try:
         json_response = json.loads(response.content, object_hook=lambda d: SimpleNamespace(**d))
     except Exception as e:
-        ui_print('[comet] error: unable to parse response:' + response.content.decode("utf-8") + " " + str(e))
+        if hasattr(response, "content"):
+            ui_print('[comet] error: unable to parse response:' + response.content.decode("utf-8"))
+        else:
+            ui_print('[comet] error: unable to parse response.')
+        ui_print('[comet] ' + str(e), ui_settings.debug)
         return []
     return json_response
 


### PR DESCRIPTION
Getting an empty response back from Comet would otherwise blow up trying to print the error.