### PR TITLE
Downloading season pack fix

### DIFF
--- a/content/classes.py
+++ b/content/classes.py
@@ -580,7 +580,7 @@ class media:
                 return '(.*?)(' + title + ':?.)(series.|[^A-Za-z0-9]+)?((\(?' + str(self.year) + '\)?.)|(complete.)|(seasons?.[0-9]+.[0-9]?[0-9]?.?)|(S[0-9]+.S?[0-9]?[0-9]?.?)|(S[0-9]+E[0-9]+))'
             elif self.type == 'season':
                 title = title.replace('.' + str(self.parentYear), '')
-                return '(.*?)(' + title + ':?.)(series.|[^A-Za-z0-9]+)?(\(?' + str(self.parentYear) + '\)?.)?(season.' + str(self.index) + '[^0-9]|season.' + str("{:02d}".format(self.index)) + '[^0-9]|S' + str("{:02d}".format(self.index)) + '[^0-9])'
+                return '(.*?)(' + title + ':?.)(series.|[^A-Za-z0-9]+)?(\(?' + str(self.parentYear) + '\)?.)?(season.' + str(self.index) + '[^0-9e]|season.' + str("{:02d}".format(self.index)) + '[^0-9e]|S' + str("{:02d}".format(self.index)) + '[^0-9e])'
             elif self.type == 'episode':
                 title = title.replace('.' + str(self.grandparentYear), '')
                 try:

--- a/debrid/services/realdebrid.py
+++ b/debrid/services/realdebrid.py
@@ -185,11 +185,11 @@ def download(element, stream=True, query='', force=False):
                                     ui_print('[realdebrid] added uncached release: ' + release.title)
                                     return True
                                 else:
-                                    ui_print(f'[realdebrid]: torrent is in {response.status} status (not cached). Looking for another release.')
+                                    ui_print(f'[realdebrid]: {release.title} is in {response.status} status (not cached). Looking for another release.')
                                     delete('https://api.real-debrid.com/rest/1.0/torrents/delete/' + torrent_id)
                                     continue
                         else:
-                            ui_print(f'[realdebrid]: torrent is in status [{response.status}] - trying a different release.')
+                            ui_print(f'[realdebrid]: {release.title} is in status [{response.status}] - trying a different release.')
                             delete('https://api.real-debrid.com/rest/1.0/torrents/delete/' + torrent_id)
                             continue
                     if response.status == 'downloaded':
@@ -206,14 +206,14 @@ def download(element, stream=True, query='', force=False):
                         ui_print('[realdebrid] added uncached release: ' + release.title)
                         return True
                     else:
-                        ui_print(f'[realdebrid]: no files found for torrent {release.title} in status {response.status}. looking for another release.', ui_settings.debug)
+                        ui_print(f'[realdebrid]: no files found for torrent {release.title} in status {response.status}. looking for another release.')
                         delete('https://api.real-debrid.com/rest/1.0/torrents/delete/' + torrent_id)
                         continue
 
                 ui_print('[realdebrid] added uncached release: ' + release.title)
                 return True
             else:
-                ui_print(f'[realdebrid] error: rejecting release: "{release.title}" because it doesnt match the allowed deviation "{query}"', ui_settings.debug)
+                ui_print(f'[realdebrid] error: rejecting release: "{release.title}" because it doesnt match the allowed deviation "{query}"')
         except Exception as e:
             ui_print(f'[realdebrid] unexpected error: ' + str(e))
     return False

--- a/debrid/services/realdebrid.py
+++ b/debrid/services/realdebrid.py
@@ -214,6 +214,7 @@ def download(element, stream=True, query='', force=False):
                 return True
             else:
                 ui_print(f'[realdebrid] error: rejecting release: "{release.title}" because it doesnt match the allowed deviation "{query}"')
+                ui_print(f'[realdebrid] if this was a mistake, you can manually add it: "{release.download[0]}"')
         except Exception as e:
             ui_print(f'[realdebrid] unexpected error: ' + str(e))
     return False


### PR DESCRIPTION
When searching for releases by complete seasons, it was including individual episode releases due to an imprecise regex: `S01[^0-9]` for season 1 for example would match "My Watchlisted Show S01 WEBRiP" but also match releases which include an episode index, e.g. S01E04.

Also minor update to include the release title when logging rejected releases during download.