### PR TITLE
Fixes AttributeError: 'season' object has no attribute 'Releases'.

### DIFF
--- a/content/classes.py
+++ b/content/classes.py
@@ -1497,6 +1497,7 @@ class media:
             if not filemode:
                 for season in self.Seasons:
                     season.version = self.version
+                    season.Releases = self.Releases
                     season.downloaded()
         elif self.type == 'season':
             filemode = False


### PR DESCRIPTION
When marking a show as "downloaded", PD will go into each of the seasons and episodes to mark each item as "downloaded". If this is from a multi-season pack, then the "Release" details weren't propagated down to each of the seasons. 

Fixes #28