### PR TITLE
Add default values to trakt client_id, client_secret when not defined

### DIFF
--- a/content/services/trakt.py
+++ b/content/services/trakt.py
@@ -8,8 +8,8 @@ from pydantic_settings import BaseSettings
 
 # Get Trakt oauth details from env
 class Settings(BaseSettings):
-    client_id: str
-    client_secret: str
+    client_id: str = ""
+    client_secret: str = ""
 
     class Config:
         env_file = ".env"


### PR DESCRIPTION
Removes the error message when attempting to start PD without a `.env` file with `client_id` and `client_secret` defined.

Fixes #18