### PR TITLE
Fixes anime_count not initialized for all episodes

### DIFF
--- a/content/classes.py
+++ b/content/classes.py
@@ -632,8 +632,6 @@ class media:
     def isanime(self):
         if 'anime' in self.genre():
             if self.type == "show":
-                if hasattr(self, "anime_count"):
-                    return True
                 self.anime_count = 0
                 if hasattr(self, 'Seasons'):
                     for season in self.Seasons:


### PR DESCRIPTION
The `media#is_anime()` function initializes some attributes (like `anime_count`, `anime_season`, `genres`) at the season and episode level (but only the first time the show is scraped). Subsequent times assume those attributes are present (but for multi-season Overseerr requests, this might not be the case). The change here removes the "short-circuit" for this function when it finds the "anime_count" field so it forces the reinitialization of the aforementioned attributes.

Don't even get me started on functions that change state with non-state changing sounding function names. Why would you expect `is_anime()` to change state?!?! GAH!

I think there is also the bigger issue here with anime episode naming in PD (episode numbering assumes all seasons and episodes have been requested). I'm not too familiar with anime so I'll leave this until somebody complains about it.

Resolves #38