### PR TITLE
TV series removed from watchlist even if auto remove set to none

### DIFF
--- a/content/classes.py
+++ b/content/classes.py
@@ -1357,7 +1357,7 @@ class media:
                             refresh_ = True
                         if result[1]:
                             retry = True
-                    if not retry and (self.watchlist.autoremove == "both" or self.watchlist.autoremove == "show" or self.hasended()):
+                    if not retry and (self.watchlist.autoremove == "both" or self.watchlist.autoremove == "show"):
                         self.watchlist.remove([], self)
                     toc = time.perf_counter()
                     ui_print('took ' + str(round(toc - tic, 2)) + 's')


### PR DESCRIPTION
Completed TV series (no more future episodes) were being removed from the Plex watchlist even if the auto remove setting was set to 'none' or 'movie'.

Resolves #41