### PR TITLE
Release 2.103: minor fixes plex/trakt; added plex rate-limiter; torrent hash deduplication

### DIFF
--- a/base/__init__.py
+++ b/base/__init__.py
@@ -94,7 +94,7 @@ class custom_session(requests.Session):
                 self.last_request_time = time.time()
 
                 if response.status_code in self.RETRY_CODES:
-                    logger.error(f"request error: {response.status_code} - retrying...")
+                    logger.error(f"request error: {response.status_code} - retrying... {url}")
                     retries += 1
                     if method == 'GET':
                         time.sleep(self.GET_RATE_LIMIT)

--- a/content/classes.py
+++ b/content/classes.py
@@ -1186,6 +1186,7 @@ class media:
         # set anime info before episodes are removed
         self.isanime()
         if self.type == 'movie':
+            ui_print(f"processing movie: {self.title} ({self.year})", debug=ui_settings.debug)
             if (len(self.uncollected(library)) > 0 or self.version_missing()) and len(self.versions()) > 0:
                 if self.released() and not self.watched() and not self.downloading():
                     if not hasattr(self, "year") or self.year == None:
@@ -1227,6 +1228,7 @@ class media:
                     if retry:
                         self.watch()
         elif self.type == 'show':
+            ui_print(f"processing show: {self.title} ({self.year})", debug=ui_settings.debug)
             if len(self.versions()) > 0 and self.released() and (not self.collected(library) or self.version_missing()) and not self.watched():
                 self.isanime()
                 self.Seasons = self.uncollected(library)
@@ -1362,6 +1364,7 @@ class media:
                     toc = time.perf_counter()
                     ui_print('took ' + str(round(toc - tic, 2)) + 's')
         elif self.type == 'season':
+            ui_print(f"processing: {self.parentTitle} {self.title}", debug=ui_settings.debug)
             debrid_downloaded = False
             for release in parentReleases:
                 if regex.match(self.deviation(), release.title, regex.I):

--- a/content/classes.py
+++ b/content/classes.py
@@ -989,6 +989,8 @@ class media:
                             if datetime.datetime.utcnow() > self.offset_airtime[offset]:
                                 return True
                         return False
+                    if not hasattr(self, 'first_aired') or self.first_aired is None:
+                        return False
                     return datetime.datetime.utcnow() > datetime.datetime.strptime(self.first_aired, '%Y-%m-%dT%H:%M:%S.000Z')
                 elif self.type == 'movie':
                     release_date = None
@@ -998,18 +1000,18 @@ class media:
                         if release.release_type == 'digital' or release.release_type == 'physical' or release.release_type == 'tv':
                             if release_date == None:
                                 release_date = release.release_date
-                            elif datetime.datetime.strptime(release_date, '%Y-%m-%d') > datetime.datetime.strptime(release.release_date, '%Y-%m-%d'):
+                            elif release.release_date is not None and datetime.datetime.strptime(release_date, '%Y-%m-%d') > datetime.datetime.strptime(release.release_date, '%Y-%m-%d'):
                                 release_date = release.release_date
                     # If no release date was found, select the theatrical release date + 2 Month delay
                     if release_date == None:
                         for release in releases:
                             if release_date == None:
                                 release_date = release.release_date
-                            elif datetime.datetime.strptime(release_date, '%Y-%m-%d') > datetime.datetime.strptime(release.release_date, '%Y-%m-%d'):
+                            elif release.release_date is not None and datetime.datetime.strptime(release_date, '%Y-%m-%d') > datetime.datetime.strptime(release.release_date, '%Y-%m-%d'):
                                 release_date = release.release_date
-                        release_date = datetime.datetime.strptime(
-                            release_date, '%Y-%m-%d') + datetime.timedelta(days=60)
-                        release_date = release_date.strftime("%Y-%m-%d")
+                        if release_date is not None:
+                            release_date = datetime.datetime.strptime(release_date, '%Y-%m-%d') + datetime.timedelta(days=60)
+                            release_date = release_date.strftime("%Y-%m-%d")
                     # Get trakt 'Latest HD/4k Releases' Lists to accept early releases
                     match = False
                     if trakt.early_releases == "true":
@@ -1023,6 +1025,8 @@ class media:
                         ui_print("item: '" + self.query() +
                                  "' seems to be released prior to its official release date and will be downloaded.")
                         return True
+                    if release_date is None:
+                        return False
                     if hasattr(self, "offset_airtime"):
                         for offset in self.offset_airtime:
                             if datetime.datetime.utcnow() > (datetime.datetime.strptime(release_date, '%Y-%m-%d') + datetime.timedelta(hours=float(offset))):
@@ -1040,6 +1044,8 @@ class media:
                     return datetime.datetime.utcnow() > datetime.datetime.strptime(release_date, '%Y-%m-%d')
                 elif self.type == 'season':
                     try:
+                        if not hasattr(self, 'first_aired') or self.first_aired is None:
+                            return False
                         if hasattr(self, "offset_airtime") and len(self.offset_airtime) > 0:
                             for offset in self.offset_airtime:
                                 if datetime.datetime.utcnow() > datetime.datetime.strptime(self.first_aired, '%Y-%m-%dT%H:%M:%S.000Z') + datetime.timedelta(hours=float(offset)):
@@ -1049,6 +1055,8 @@ class media:
                     except:
                         return True
                 elif self.type == 'episode':
+                    if not hasattr(self, 'first_aired') or self.first_aired is None:
+                        return False
                     if hasattr(self, "offset_airtime"):
                         for offset in self.offset_airtime:
                             if datetime.datetime.utcnow() > datetime.datetime.strptime(self.first_aired, '%Y-%m-%dT%H:%M:%S.000Z') + datetime.timedelta(hours=float(offset)):

--- a/content/services/plex.py
+++ b/content/services/plex.py
@@ -5,7 +5,7 @@ from content import classes
 from ui.ui_print import *
 
 name = 'Plex'
-session = requests.Session()
+session = custom_session(get_rate_limit=1.0, post_rate_limit=1.0)  # 1 second between requests = 60 requests/minute
 users = []
 headers = {'Content-Type': 'application/json', 'Accept': 'application/json'}
 current_library = []
@@ -28,7 +28,7 @@ def logerror(response):
         else:
             ui_print("plex error: (401 unauthorized): token for user '"+name+"' does not seem to work. check your plex user settings.")
 
-def get(url, timeout=60):
+def get(session: requests.Session, url: str, timeout=60):
     try:
         response = session.get(url, headers=headers, timeout=timeout)
         logerror(response)
@@ -38,7 +38,7 @@ def get(url, timeout=60):
         ui_print("plex error: (json exception): " + str(e), debug=ui_settings.debug)
         return None
 
-def post(url, data):
+def post(session: requests.Session, url: str, data):
     try:
         response = session.post(url, data=data, headers=headers)
         logerror(response)
@@ -69,7 +69,7 @@ class watchlist(classes.watchlist):
                 while added < total:
                     total = 0
                     url = 'https://metadata.provider.plex.tv/library/sections/watchlist/all?X-Plex-Container-Size=200&X-Plex-Container-Start=' + str(added) + '&X-Plex-Token=' + user[1]
-                    response = get(url)
+                    response = get(session, url)
                     if hasattr(response, 'MediaContainer'):
                         total = response.MediaContainer.totalSize
                         added += response.MediaContainer.size
@@ -134,7 +134,7 @@ class watchlist(classes.watchlist):
         try:
             for user in users:
                 url = 'https://metadata.provider.plex.tv/library/sections/watchlist/all?X-Plex-Token=' + user[1]
-                response = get(url)
+                response = get(session, url)
                 if hasattr(response, 'MediaContainer'):
                     if hasattr(response.MediaContainer, 'Metadata'):
                         for entry in response.MediaContainer.Metadata:
@@ -180,7 +180,7 @@ class season(classes.media):
         viewCount = 0
         while len(self.Episodes) < self.leafCount:
             url = 'https://metadata.provider.plex.tv/library/metadata/' + self.ratingKey + '/children?includeUserState=1&X-Plex-Container-Size=200&X-Plex-Container-Start=' + str(len(self.Episodes)) + '&X-Plex-Token=' + token
-            response = get(url)
+            response = get(session, url)
             if not response == None:
                 if hasattr(response, 'MediaContainer'):
                     self.duration = 0
@@ -226,13 +226,13 @@ class show(classes.media):
         success = False
         while not success:
             url = 'https://metadata.provider.plex.tv/library/metadata/' + ratingKey + '?includeUserState=1&X-Plex-Token=' + token
-            response = get(url)
+            response = get(session, url)
             if not response == None:
                 self.__dict__.update(response.MediaContainer.Metadata[0].__dict__)
                 self.EID = setEID(self)
                 self.Seasons = []
                 url = 'https://metadata.provider.plex.tv/library/metadata/' + ratingKey + '/children?includeUserState=1&X-Plex-Container-Size=200&X-Plex-Container-Start=0&X-Plex-Token=' + token
-                response = get(url)
+                response = get(session, url)
                 if not response == None:
                     if hasattr(response, 'MediaContainer'):
                         if hasattr(response.MediaContainer, 'Metadata'):
@@ -286,7 +286,7 @@ class movie(classes.media):
         elif ratingKey.startswith('plex://'):
             ratingKey = ratingKey.split('/')[-1]
         url = 'https://metadata.provider.plex.tv/library/metadata/' + ratingKey + '?includeUserState=1&X-Plex-Token=' + token
-        response = get(url)
+        response = get(session, url)
         self.__dict__.update(response.MediaContainer.Metadata[0].__dict__)
         self.EID = setEID(self)
         if not hasattr(self,"watchlistedAt"):
@@ -346,7 +346,7 @@ class library(classes.library):
             working = False
             while not working:
                 try:
-                    response = get(library.url  + '/library/sections/?X-Plex-Token=' + users[0][1])
+                    response = get(session, library.url  + '/library/sections/?X-Plex-Token=' + users[0][1])
                     working = True
                     if len(response.MediaContainer.Directory) == 0:
                         print("It looks like this server does not have any libraries set-up! Please open the plex webui, setup at least one library and point it to your mounted debrid service drive.")
@@ -480,7 +480,7 @@ class library(classes.library):
                             while refreshing:
                                 refreshing = False
                                 url = library.url + '/library/sections/?X-Plex-Token=' + users[0][1]
-                                response = get(url)
+                                response = get(session, url)
                                 for section_ in response.MediaContainer.Directory:
                                     if section_.refreshing:
                                         refreshing = True
@@ -501,7 +501,7 @@ class library(classes.library):
                 names = []
                 element_type = ("show" if element.type in ["show","season","episode"] else "movie")
                 url = library.url + '/library/sections/?X-Plex-Token=' + users[0][1]
-                response = get(url)
+                response = get(session, url)
                 paths = []
                 for section_ in response.MediaContainer.Directory:
                     if section_.key in library.refresh.sections and element_type == section_.type:
@@ -547,7 +547,7 @@ class library(classes.library):
             working = False
             while not working:
                 try:
-                    response = get(library.url  + '/library/sections/?X-Plex-Token=' + users[0][1])
+                    response = get(session, library.url  + '/library/sections/?X-Plex-Token=' + users[0][1])
                     working = True
                     if len(response.MediaContainer.Directory) == 0:
                         print("It looks like this server does not have any libraries set-up! Please open the plex webui, setup at least one library and point it to your mounted debrid service drive.")
@@ -595,7 +595,7 @@ class library(classes.library):
                     url = library.url + '/library/sections/' + str(library_item.librarySectionID) + '/all?type=' + type_string + '&id=' + library_item.ratingKey + '&label.locked=1' + tags_string + '&X-Plex-Token=' + users[0][1]
                     response = session.put(url,headers=headers)
                 url = library.url + '/library/metadata/' + library_item.ratingKey + '?X-Plex-Token=' + users[0][1]
-                response = get(url)
+                response = get(session, url)
                 library_item.__dict__.update(response.MediaContainer.Metadata[0].__dict__)
             except Exception as e:
                 ui_print("[plex] error: couldnt add labels! Turn on debug printing for more info.")
@@ -729,7 +729,7 @@ class library(classes.library):
                     return
                 ui_print('[plex] ignoring item: ' + self.query() + " for user: '" + ignoreuser + "'")
                 url = 'https://metadata.provider.plex.tv/actions/scrobble?identifier=tv.plex.provider.metadata&key=' + self.ratingKey + '&X-Plex-Token=' + user[1]
-                get(url)
+                get(session, url)
                 if not self in classes.ignore.ignored:
                     classes.ignore.ignored += [self]
             except Exception as e:
@@ -748,7 +748,7 @@ class library(classes.library):
                     return
                 ui_print('[plex] un-ignoring item: ' + self.query() + " for user: '" + ignoreuser + "'")
                 url = 'https://metadata.provider.plex.tv/actions/unscrobble?identifier=tv.plex.provider.metadata&key=' + self.ratingKey + '&X-Plex-Token=' + user[1]
-                get(url)
+                get(session, url)
                 if self in classes.ignore.ignored:
                     classes.ignore.ignored.remove(self)
             except Exception as e:
@@ -785,7 +785,7 @@ class library(classes.library):
         if library.check == [['']]:
             library.check = []
         try:
-            response = get(library.url  + '/library/sections/?X-Plex-Token=' + users[0][1])
+            response = get(session, library.url  + '/library/sections/?X-Plex-Token=' + users[0][1])
             for Directory in response.MediaContainer.Directory:
                 if ([Directory.key] in library.check or library.check == []) and Directory.type in ["movie","show"]:
                     types = ['1'] if Directory.type == "movie" else  ['2', '3', '4']
@@ -804,7 +804,7 @@ class library(classes.library):
             section_title = ''
             for type in types:
                 url = library.url + '/library/sections/' + section + '/all?type=' + type + '&X-Plex-Token=' + users[0][1]
-                response = get(url)
+                response = get(session, url)
                 if hasattr(response, 'MediaContainer'):
                     if hasattr(response.MediaContainer, 'Metadata'):
                         for element in response.MediaContainer.Metadata:
@@ -860,7 +860,7 @@ class library(classes.library):
                 if not item in current_library:
                     updated = True
                     url = library.url + '/library/metadata/' + item.ratingKey + '?X-Plex-Token=' + users[0][1]
-                    response = get(url)
+                    response = get(session, url)
                     item.__dict__.update(response.MediaContainer.Metadata[0].__dict__)
                 else:
                     match = next((x for x in current_library if item == x), None)
@@ -888,7 +888,7 @@ class library(classes.library):
 def search(query, library=[]):
     query = query.replace(' ', '%20')
     url = 'https://metadata.provider.plex.tv/library/search?query=' + query + '&limit=20&searchTypes=movies%2Ctv&includeMetadata=1&X-Plex-Token=' + users[0][1]
-    response = get(url)
+    response = get(session, url)
     try:
         return response.MediaContainer.SearchResult
     except:
@@ -934,7 +934,7 @@ def match(self):
         service,query = EID.split('://')
         query = '-'.join([service,query])
         url = current_module.library.url + '/library/metadata/' + some_local_media.ratingKey + '/matches?manual=1&title=' + query + '&agent=' + agent + '&language=en-US&X-Plex-Token=' + users[0][1]
-        response = get(url)
+        response = get(session, url)
         try:
             match = response.MediaContainer.SearchResult[0]
             if match.type == 'show':

--- a/content/services/trakt.py
+++ b/content/services/trakt.py
@@ -232,9 +232,10 @@ def post(url, data):
 
 def post2(url, data):
     try:
-        response = session.post(url, headers={
-            'Content-type': "application/json"}, data=data)
-        logerror(response)
+        response = session.post(url, headers={'Content-type': "application/json"}, data=data)
+        if response.status_code not in [200, 201]:
+            ui_print(f"[trakt] error {response.status_code}: " + str(response.content), ui_settings.debug)
+            return None
         response = json.loads(response.content, object_hook=lambda d: SimpleNamespace(**d))
         time.sleep(1.1)
     except Exception as e:

--- a/scraper/__init__.py
+++ b/scraper/__init__.py
@@ -34,6 +34,23 @@ def scrape(query, altquery="(.*)"):
         for result in results:
             if not result == [] and not result == None:
                 scraped_releases += result
+        # consolidate duplicate torrent releases by identical hash across sources
+        consolidated = []
+        index_by_hash = {}
+        for rel in scraped_releases:
+            try:
+                if getattr(rel, 'type', None) == 'torrent' and getattr(rel, 'hash', ''):
+                    key = rel.hash.lower()
+                    if key in index_by_hash:
+                        consolidated[index_by_hash[key]].merge(rel)
+                    else:
+                        index_by_hash[key] = len(consolidated)
+                        consolidated.append(rel)
+                else:
+                    consolidated.append(rel)
+            except:
+                consolidated.append(rel)
+        scraped_releases = consolidated
         for release in scraped_releases:
             release.title = ''.join([i if ord(i) < 512 else '' for i in release.title])
         ui_print('done - found ' + str(len(scraped_releases)) + ' releases')

--- a/scraper/services/mediafusion.py
+++ b/scraper/services/mediafusion.py
@@ -27,6 +27,8 @@ def request(func, *args):
         return []
 
     try:
+        if not hasattr(response, "content") or len(response.content) == 0:
+            return []
         json_response = json.loads(response.content, object_hook=lambda d: SimpleNamespace(**d))
     except Exception as e:
         ui_print('[mediafusion] error: unable to parse response:' + response.content.decode("utf-8") + " " + str(e))

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -277,7 +277,8 @@ def save(doprint=True):
         if doprint:
             print('Current settings saved!')
             time.sleep(2)
-    except:
+    except Exception as e:
+        print(str(e))
         print()
         print("Error: It looks like plex_debrid can not write your settings into a config file. Make sure you are running the script with write or administator privilege.")
         print()

--- a/ui/ui_settings.py
+++ b/ui/ui_settings.py
@@ -1,4 +1,4 @@
-version = ['2.102', "Settings compatible update", []]
+version = ['2.103', "Settings compatible update", []]
 run_directly = "true"
 debug = "false"
 log = "false"


### PR DESCRIPTION
Bump version to 2.103
* torrent hash deduplication when identifying torrent releases
* trakt: avoid printing full stack trace during token authorisation
* trakt: fix intermittent errors with strptime()
* plex: rate limit api requests
* additional error handling for failed responses
* additional debug logging during processing loop